### PR TITLE
Mark shell-version 3.18 as supported

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,1 +1,1 @@
-{"shell-version": ["3.8","3.10","3.12","3.14","3.16"], "uuid": "show-ip@sgaraud.github.com", "version": 1, "url": "https://github.com/sgaraud/gnome-extension-show-ip", "name": "Show IP", "description": "Show private IP address in gnome-shell bar"}
+{"shell-version": ["3.8","3.10","3.12","3.14","3.16","3.18"], "uuid": "show-ip@sgaraud.github.com", "version": 1, "url": "https://github.com/sgaraud/gnome-extension-show-ip", "name": "Show IP", "description": "Show private IP address in gnome-shell bar"}


### PR DESCRIPTION
Tested with wired, wireless, and virtual interfaces. 

Does not emit any errors on load.
