### PR TITLE
Show the primary IP address when no interface was chosen

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ issues](https://github.com/sgaraud/gnome-extension-show-ip/issues).
 ### License
 
 Copyright (C) 2015 Sylvain Garaud
+Copyright 2017 Paul Wise
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Makes it easier to see all IP addresses at a glance.

Uses NM to get which interface(s) are in the default route.